### PR TITLE
Disabled acces to external entities in Xml parsing

### DIFF
--- a/RDFSharp/Model/Serializers/RDFTriX.cs
+++ b/RDFSharp/Model/Serializers/RDFTriX.cs
@@ -203,6 +203,7 @@ namespace RDFSharp.Model
                 {
                     using (XmlTextReader trixReader = new XmlTextReader(streamReader))
                     {
+                        trixReader.XmlResolver = null;
                         trixReader.DtdProcessing = DtdProcessing.Parse;
                         trixReader.Normalization = false;
                         XmlDocument trixDoc = new XmlDocument();

--- a/RDFSharp/Model/Serializers/RDFXml.cs
+++ b/RDFSharp/Model/Serializers/RDFXml.cs
@@ -379,6 +379,7 @@ namespace RDFSharp.Model
                 {
                     using (XmlTextReader xmlReader = new XmlTextReader(streamReader))
                     {
+                        xmlReader.XmlResolver = null;
                         xmlReader.DtdProcessing = DtdProcessing.Parse;
                         xmlReader.Normalization = false;
 

--- a/RDFSharp/Query/Mirella/Algebra/Queries/RDFAskQueryResult.cs
+++ b/RDFSharp/Query/Mirella/Algebra/Queries/RDFAskQueryResult.cs
@@ -134,6 +134,7 @@ namespace RDFSharp.Query
                 {
                     using (XmlTextReader xmlReader = new XmlTextReader(streamReader))
                     {
+                        xmlReader.XmlResolver = null;
                         xmlReader.DtdProcessing = DtdProcessing.Parse;
                         xmlReader.Normalization = false;
 

--- a/RDFSharp/Query/Mirella/Algebra/Queries/RDFSelectQueryResult.cs
+++ b/RDFSharp/Query/Mirella/Algebra/Queries/RDFSelectQueryResult.cs
@@ -231,6 +231,7 @@ namespace RDFSharp.Query
                 {
                     using (XmlTextReader xmlReader = new XmlTextReader(streamReader))
                     {
+                        xmlReader.XmlResolver = null;
                         xmlReader.DtdProcessing = DtdProcessing.Parse;
                         xmlReader.Normalization = false;
 

--- a/RDFSharp/Store/Serializers/RDFTriX.cs
+++ b/RDFSharp/Store/Serializers/RDFTriX.cs
@@ -103,6 +103,7 @@ namespace RDFSharp.Store
                 {
                     using (XmlTextReader trixReader = new XmlTextReader(streamReader))
                     {
+                        trixReader.XmlResolver = null;
                         trixReader.DtdProcessing = DtdProcessing.Parse;
                         trixReader.Normalization = false;
                         XmlDocument trixDoc = new XmlDocument();


### PR DESCRIPTION
Kikapcsoltam az ismeretlen forrásból származó fájlok olvasását, ami biztonsági rést jelentett.