### PR TITLE
Revert "Disabled acces to external entities in Xml parsing"

### DIFF
--- a/RDFSharp/Model/Serializers/RDFTriX.cs
+++ b/RDFSharp/Model/Serializers/RDFTriX.cs
@@ -203,7 +203,6 @@ namespace RDFSharp.Model
                 {
                     using (XmlTextReader trixReader = new XmlTextReader(streamReader))
                     {
-                        trixReader.XmlResolver = null;
                         trixReader.DtdProcessing = DtdProcessing.Parse;
                         trixReader.Normalization = false;
                         XmlDocument trixDoc = new XmlDocument();

--- a/RDFSharp/Model/Serializers/RDFXml.cs
+++ b/RDFSharp/Model/Serializers/RDFXml.cs
@@ -379,7 +379,6 @@ namespace RDFSharp.Model
                 {
                     using (XmlTextReader xmlReader = new XmlTextReader(streamReader))
                     {
-                        xmlReader.XmlResolver = null;
                         xmlReader.DtdProcessing = DtdProcessing.Parse;
                         xmlReader.Normalization = false;
 

--- a/RDFSharp/Query/Mirella/Algebra/Queries/RDFAskQueryResult.cs
+++ b/RDFSharp/Query/Mirella/Algebra/Queries/RDFAskQueryResult.cs
@@ -134,7 +134,6 @@ namespace RDFSharp.Query
                 {
                     using (XmlTextReader xmlReader = new XmlTextReader(streamReader))
                     {
-                        xmlReader.XmlResolver = null;
                         xmlReader.DtdProcessing = DtdProcessing.Parse;
                         xmlReader.Normalization = false;
 

--- a/RDFSharp/Query/Mirella/Algebra/Queries/RDFSelectQueryResult.cs
+++ b/RDFSharp/Query/Mirella/Algebra/Queries/RDFSelectQueryResult.cs
@@ -231,7 +231,6 @@ namespace RDFSharp.Query
                 {
                     using (XmlTextReader xmlReader = new XmlTextReader(streamReader))
                     {
-                        xmlReader.XmlResolver = null;
                         xmlReader.DtdProcessing = DtdProcessing.Parse;
                         xmlReader.Normalization = false;
 

--- a/RDFSharp/Store/Serializers/RDFTriX.cs
+++ b/RDFSharp/Store/Serializers/RDFTriX.cs
@@ -103,7 +103,6 @@ namespace RDFSharp.Store
                 {
                     using (XmlTextReader trixReader = new XmlTextReader(streamReader))
                     {
-                        trixReader.XmlResolver = null;
                         trixReader.DtdProcessing = DtdProcessing.Parse;
                         trixReader.Normalization = false;
                         XmlDocument trixDoc = new XmlDocument();


### PR DESCRIPTION
Reverts BME-MIT-IET/iet-hf-2022-we-rdfs#14
Nem oldotta meg a Sonar Cloud szerint a biztonsági hibákat, bár a vizsgálatom alapján ez helyesnek tünt, de @dominikvaradi talált egy jobb megoldást.